### PR TITLE
Add language-specific modules into the core build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ utilities/rdbmigration/.work
 **/.idea
 **/*.iml
 **/target
+*~
 
 **/overlays
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Available language files
 
 At present, VIVO has been translated into German, Spanish, and Portuguese. You may find the relevant files for each language by searching for files containing _de_DE, _es, and _pt_BR respectively. English uses the prefix _en_US.
 
+**Note**: Whenever a new language is added to this project the following file must be updated to include it:
+`core/webapp/src/main/webapp/i18n/available-langs.properties`
+
 Using the language files
 ------------------------
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,11 +3,18 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>vitro-languages-core</artifactId>
+    <version>1.11.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Vitro Languages CORE</name>
     <description>Vitro Languages</description>
     <url>http://vivoweb.org/</url>
+
+    <parent>
+        <groupId>org.vivoweb</groupId>
+        <artifactId>vitro-languages</artifactId>
+        <version>1.11.2-SNAPSHOT</version>
+    </parent>
 
     <licenses>
         <license>
@@ -149,55 +156,38 @@
         </profile> 
     </profiles>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-                <plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-war-plugin</artifactId>
-					<version>3.2.3</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>1.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.vivoweb</groupId>
+            <artifactId>vitro-languages-webapp-en_US</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.vivoweb</groupId>
+            <artifactId>vitro-languages-webapp-de_DE</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.vivoweb</groupId>
+            <artifactId>vitro-languages-webapp-es</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.vivoweb</groupId>
+            <artifactId>vitro-languages-webapp-fr_CA</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.vivoweb</groupId>
+            <artifactId>vitro-languages-webapp-pt_BR</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
 
     <distributionManagement>
         <site>
@@ -213,11 +203,4 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    <parent>
-    	<groupId>org.vivoweb</groupId>
-    	<artifactId>vitro-languages</artifactId>
-    	<version>1.11.2-SNAPSHOT</version>
-    </parent>
-    <groupId>org.vivoweb</groupId>
-    <version>1.11.2-SNAPSHOT</version>
 </project>

--- a/core/webapp/src/main/webapp/i18n/available-langs.properties
+++ b/core/webapp/src/main/webapp/i18n/available-langs.properties
@@ -1,0 +1,5 @@
+de_DE
+en_US
+es
+fr_CA
+pt_BR


### PR DESCRIPTION
Add new 'available-langs.properties' file used in Vitro to filter out language files that are not enabled in the Vitro configuration

## Related pull-requests
* https://github.com/vivo-project/VIVO-languages/pull/41
* https://github.com/vivo-project/Vitro/pull/160
* https://github.com/vivo-project/VIVO/pull/168

Part of resolution to: https://jira.lyrasis.org/browse/VIVO-1836