### PR TITLE
Ensure RDF files are assembled into language-specific directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ Available language files
 
 At present, VIVO has been translated into German, Spanish, and Portuguese. You may find the relevant files for each language by searching for files containing _de_DE, _es, and _pt_BR respectively. English uses the prefix _en_US.
 
-**Note**: Whenever a new language is added to this project the following file must be updated to include it:
-`core/webapp/src/main/webapp/i18n/available-langs.properties`
-
 Using the language files
 ------------------------
 

--- a/core/webapp/src/main/webapp/i18n/available-langs.properties
+++ b/core/webapp/src/main/webapp/i18n/available-langs.properties
@@ -1,6 +1,0 @@
-de_DE
-en_US
-es
-fr_CA
-pt_BR
-en_CA


### PR DESCRIPTION
- Remove 'available-langs.properties'

Related PRs:
- https://github.com/vivo-project/VIVO-languages/pull/57
- https://github.com/vivo-project/VIVO/pull/174
- https://github.com/vivo-project/Vitro/pull/169

Related to: https://jira.lyrasis.org/browse/VIVO-1848