### PR TITLE
[VIVO-1901] i18n: translated the german termsOfUse in german

### DIFF
--- a/de_DE/webapp/src/main/webapp/templates/freemarker/termsOfUse_de_DE.ftl
+++ b/de_DE/webapp/src/main/webapp/templates/freemarker/termsOfUse_de_DE.ftl
@@ -1,34 +1,50 @@
 <#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
 
 <section id="terms" role="region">
-    <h2>Terms of Use</h2>
+    <h2>Nutzungsbedingungen</h2>
+    <p>Dieser gesamte Text dient als Platzhalter und sollte von jedem Betreiber/in auf seine/ihre Bedürfnisse angepasst werden</p>
     
-    <h3>Disclaimers</h3>
-    <p>This ${termsOfUse.siteName} website contains material&mdash;text information, publication
-    citations, links, and images&mdash;provided by ${termsOfUse.siteHost} and by various
-    third parties, both individuals and organizations, commercial and otherwise. To the extent copyrightable,
-    the information presented on the VIVO website and available as Resource Description Framework (RDF) data
-    from VIVO at ${termsOfUse.siteHost} is intended for public use and is freely distributed under the terms of the
-    <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank" title="creative commons">Creative Commons CC-BY 3.0</a> license which allows you
-    to copy, distribute, display and make derivatives of this information provided you give credit to 
-    ${termsOfUse.siteHost}. Any non-copyrightable information is available to you under a
-    <a href="http://creativecommons.org/publicdomain/zero/1.0/"  target="_blank" title="cco waiver">CC0 waiver</a>.  However, source documents,
-    images or web pages attached to or linked from VIVO may contain copyrighted information and should only be
-    used or distributed under terms included with each source or in accordance with the principles of fair use.
+    <h3>Allgemeine Haftungsausschlüsse</h3>
+    <p>Die Website von ${termsOfUse.siteName} enthält Material, wie etwa Textinformationen,
+    Auszüge aus Veröffentlichungen, Links und Bilder, das von ${termsOfUse.siteHost}
+    und verschiedenen Dritten, darunter Privatpersonen als auch
+    Unternehmen, kommerziell oder anderweitig bereitgestellt wird. Soweit
+    urheberrechtlich geschützt, sind die auf der Website von VIVO
+    dargestellten und als Resource Description Framework (RDF) verfügbaren
+    Daten von VIVO im ${termsOfUse.siteHost} für die öffentliche Nutzung bestimmt und
+    unter den Bedingungen der Lizenz <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank" title="creative commons">Creative Commons CC-BY 3.0</a> frei
+    verfügbar. Diese Lizenz ermöglicht die Vervielfältigung, Verbreitung,
+    Aufführung und Veränderung der Informationen, vorausgesetzt, ${termsOfUse.siteHost} wird als Quelle genannt. 
+    Alle nicht urheberrechtlich geschützten Informationen stehen im Rahmen einer <a href="http://creativecommons.org/publicdomain/zero/1.0/"  target="_blank" title="cco waiver">CC0-Verzichtserklärung</a> zur
+    Verfügung. Mit VIVO verbundene oder von VIVO verlinkte Quellmaterialien,
+    Bilder oder Webseiten können hingegen urheberrechtlich geschützte
+    Informationen enthalten und sollten nur unter den der Quelle beigefügten
+    Bedingungen oder in Übereinstimmung mit den Grundsätzen der fairen
+    Nutzung verwendet oder verbreitet werden.
     </p>
     
-    <h3>Disclaimer of Liability</h3>
-    <p>${termsOfUse.siteHost?cap_first} makes no warranty, expressed or implied, including the warranties of merchantability 
-    and fitness for a particular purpose, or assumes any legal liability or responsibility for the accuracy, 
-    completeness, currency or usefulness of any material displayed or distributed through the 
-     ${termsOfUse.siteName} website or represents that its use would not infringe privately owned rights. 
-    ${termsOfUse.siteHost?cap_first} disclaims all warranties with regard to the information provided. Any reliance upon such information 
-    is at your own risk. In no event will ${termsOfUse.siteHost} be liable to you for any damages or losses whatsoever resulting 
-    from or caused by the ${siteName} website or its contents.</p> 
+    <h3>Haftung für Inhalte</h3>
+    <p>${termsOfUse.siteHost?cap_first} übernimmt keine Garantie, ausdrücklich oder implizit,
+    einschließlich der Zusicherung bezüglich der Gebrauchstauglichkeit und
+    Eignung für einen bestimmten Zweck, noch übernimmt ${termsOfUse.siteHost}
+    jegliche Haftung oder Verantwortung für die Richtigkeit, Vollständigkeit,
+    Aktualität oder den Nutzen des über die Website von ${termsOfUse.siteName} dargestellten
+    oder verbreiteten Materials, noch vertritt ${termsOfUse.siteHost}, dass der Gebrauch
+    davon nicht gegen Rechte Dritter verstößt. ${termsOfUse.siteHost} lehnt jede
+    Gewährleistung in Bezug auf die bereitgestellten Informationen ab.
+    Jegliches Vertrauen in die Informationen geschieht auf eigene Gefahr. In
+    keinem Fall haftet ${termsOfUse.siteHost} für Schäden oder Verluste, die sich aus der
+    Benutzung der Website von ${termsOfUse.siteName} oder deren Inhalte ergeben bzw. durch
+    sie verursacht werden.
+    </p> 
     
-    <h3>Disclaimer of Endorsement</h3>
-    <p>Reference herein to any specific commercial product, process, or service by trade name, 
-    trademark, manufacturer, or otherwise, does not necessarily constitute or imply its endorsement or recommendation 
-    by ${termsOfUse.siteHost}. The views and opinions of authors expressed herein do not necessarily state or reflect those of 
-    ${termsOfUse.siteHost} and shall not be used for advertising or product endorsement purposes.</p> 
+    <h3>Haftung für Werbung</h3>
+    <p>Die hier enthaltenen Bezugnahmen auf bestimmte kommerzielle Produkte,
+    Verfahren oder Dienstleistungen durch Handelsnamen, Markennamen,
+    Hersteller oder andere Verweise bedeuten nicht zwangsläufig eine
+    Befürwortung oder Weiterempfehlung durch ${termsOfUse.siteHost}. Die hierin
+    geäußerten Ansichten und Meinungen der Autoren spiegeln nicht
+    notwendigerweise die Ansichten und Meinungen von ${termsOfUse.siteHost} wider
+    und dürfen nicht für Werbe- oder Produktvermarktungszwecke verwendet
+    werden.</p> 
 </section>


### PR DESCRIPTION
[JIRA Issue](https://jira.lyrasis.org/browse/VIVO-1901)

The file termsOfUse_de_DE.ftl was still in english, i translated it into german.