### PR TITLE
Moving some Vitro related properties from VIVO-languages

### DIFF
--- a/de_DE/webapp/src/main/webapp/i18n/all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/all_de_DE.properties
@@ -943,3 +943,10 @@ data_not_past_msg = Bitte geben Sie ein zukünftiges Zieldatum für die Veröffe
 invalid_date_form_msg = muss im gültigen Datumsformat mm/tt/jjjj sein.
 file_must_be_entered_msg = für dieses Feld muss eine Datei eingegeben werden.
 invalid_url_msg = Diese URL muss mit http:// oder https:// beginnen.
+
+label.dateTimeWithPrecision.year_capitalized = Jahr
+label.dateTimeWithPrecision.month_capitalized = Monat
+label.dateTimeWithPrecision.day_capitalized = Tag
+label.dateTimeWithPrecision.hour_capitalized = Stunde
+label.dateTimeWithPrecision.minutes_capitalized = Minuten
+label.dateTimeWithPrecision.seconds_capitalized = Sekunden

--- a/en_CA/webapp/src/main/webapp/i18n/all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/all_en_CA.properties
@@ -952,3 +952,10 @@ data_not_past_msg = Please enter a future target date for publication (past date
 invalid_date_form_msg = must be in valid date format mm/dd/yyyy.
 file_must_be_entered_msg = a file must be entered for this field.
 invalid_url_msg = This URL must start with http:// or https://
+
+label.dateTimeWithPrecision.year_capitalized = Year
+label.dateTimeWithPrecision.month_capitalized = Month
+label.dateTimeWithPrecision.day_capitalized = Day
+label.dateTimeWithPrecision.hour_capitalized = Hour
+label.dateTimeWithPrecision.minutes_capitalized = Minutes
+label.dateTimeWithPrecision.seconds_capitalized = Seconds

--- a/en_US/webapp/src/main/webapp/i18n/all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/all_en_US.properties
@@ -954,3 +954,9 @@ invalid_date_form_msg = must be in valid date format mm/dd/yyyy.
 file_must_be_entered_msg = a file must be entered for this field.
 invalid_url_msg = This URL must start with http:// or https://
 
+label.dateTimeWithPrecision.year_capitalized = Year
+label.dateTimeWithPrecision.month_capitalized = Month
+label.dateTimeWithPrecision.day_capitalized = Day
+label.dateTimeWithPrecision.hour_capitalized = Hour
+label.dateTimeWithPrecision.minutes_capitalized = Minutes
+label.dateTimeWithPrecision.seconds_capitalized = Seconds

--- a/es/webapp/src/main/webapp/i18n/all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/all_es.properties
@@ -938,3 +938,10 @@ data_not_past_msg = Introduzca una fecha objetivo futura para la publicación (l
 invalid_date_form_msg = debe tener un formato de fecha válido mm / dd / aaaa.
 file_must_be_entered_msg = se debe ingresar un archivo para este campo.
 invalid_url_msg = Esta URL debe comenzar con http: // o https: //
+
+label.dateTimeWithPrecision.year_capitalized = Año
+label.dateTimeWithPrecision.month_capitalized = Mes
+label.dateTimeWithPrecision.day_capitalized = Día
+label.dateTimeWithPrecision.hour_capitalized = Hora
+label.dateTimeWithPrecision.minutes_capitalized = Minutas
+label.dateTimeWithPrecision.seconds_capitalized = Segundos

--- a/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties
@@ -958,3 +958,10 @@ data_not_past_msg = Veuillez saisir une date cible future pour la publication (l
 invalid_date_form_msg = doit être au format mm/jj/aaaa.
 file_must_be_entered_msg = un fichier doit être spécifié pour ce champ.
 invalid_url_msg = Cette URL doit commencer par http:// ou https://
+
+label.dateTimeWithPrecision.year_capitalized = Année
+label.dateTimeWithPrecision.month_capitalized = Mois
+label.dateTimeWithPrecision.day_capitalized = Jour
+label.dateTimeWithPrecision.hour_capitalized = Heure
+label.dateTimeWithPrecision.minutes_capitalized = Minutes
+label.dateTimeWithPrecision.seconds_capitalized = Secondes

--- a/pt_BR/webapp/src/main/webapp/i18n/all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/all_pt_BR.properties
@@ -954,3 +954,10 @@ data_not_past_msg = Insira uma data alvo futura para publicação (datas anterio
 invalid_date_form_msg = deve estar em formato de data válido mm / dd / aaaa.
 file_must_be_entered_msg = um arquivo deve ser inserido para este campo.
 invalid_url_msg = Este URL deve começar com http: // ou https: //
+
+label.dateTimeWithPrecision.year_capitalized =  Ano
+label.dateTimeWithPrecision.month_capitalized = Mês
+label.dateTimeWithPrecision.day_capitalized = Dia
+label.dateTimeWithPrecision.hour_capitalized = Hora
+label.dateTimeWithPrecision.minutes_capitalized = Minutos
+label.dateTimeWithPrecision.seconds_capitalized = Segundos


### PR DESCRIPTION
Fix to : https://jira.lyrasis.org/browse/VIVO-1877
Related PR : 
https://github.com/vivo-project/VIVO-languages/pull/89
https://github.com/vivo-project/Vitro/pull/203

### What does it do?
Adds properties needed to replace hardcoded time units in dateTimeWithPrecision.ftl
Original PR was https://github.com/vivo-project/VIVO-languages/pull/89 but it was decided to move the properties from VIVO-languages to Vitro-languages for code consistency/self-containment  (see https://github.com/vivo-project/VIVO-languages/pull/89#issuecomment-769341799).

My original plan was to group the properties with other time related properties, but after noticing there were small differences between the files anyway, I just added them at the end of the file.

### How to test it

With branches VIVO-1877 checked out in Vitro, Vitro-languages and VIVO-languages, browse to **Events > [some event] > Overview > date/time interval > add** and check labels in the form.

Fix has been tested with fr_CA, en_CA, en_US, pt_BR, de_DE and es contexts.