### PR TITLE
[VIVO-1793] i18n: removed duplicate entry in all_fr_CA.properties

### DIFF
--- a/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties
@@ -947,7 +947,6 @@ maximum_cardinality = cardinalité maximale
 cardinality = cardinalité
 not = ne pas
 and = et
-or = ou
 
 #
 # validation messages ( BasicValidationVTwo.java )


### PR DESCRIPTION
Somehow related ticket [Jira](https://jira.lyrasis.org/browse/VIVO-1793)

The task from the ticket was already done but i noticed that the entry in "Vitro-languages/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties" was duplicated. So i removed one. 