### PR TITLE
Issue/vivo 1979

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available language files
 At present, Vitro has been translated into American English (en_US),
 Canadian English (en_CA), Canadian French (fr_CA), German (de_DE),
 Spanish (es), and Brazilian Portuguese (pt_BR). Each available
-language has it own top-level directory in this repository.
+language has its own top-level directory in this repository.
 
 Using the language files
 ------------------------

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 Vitro-languages
 ===============
 
-Files that enable Vitro (and by extension, VIVO) to operate in languages beyond American English.
+Files required for displaying the Vitro (and by extension, VIVO) user interface
+in different natural languages, including American English.
 
 Available language files
 ------------------------
 
-At present, VIVO has been translated into German, Spanish, and Portuguese. You may find the relevant files for each language by searching for files containing _de_DE, _es, and _pt_BR respectively. English uses the prefix _en_US.
+At present, Vitro has been translated into American English (en_US),
+Canadian English (en_CA), Canadian French (fr_CA), German (de_DE),
+Spanish (es), and Brazilian Portuguese (pt_BR). Each available
+language has it own top-level directory in this repository.
 
 Using the language files
 ------------------------
 
-If the files you want already exist here, you can add them to your VIVO instance by
-following the instructions in the VIVO wiki for [Adding a language to VIVO][1].
+If a directory for a language you want to use already exists here, you can
+enable this language in your Vitro/VIVO instance by following the instructions
+in the VIVO wiki for [Adding a language to VIVO][1].
 
-If the files for your desired language do not exist then you may use the files in this repository as a
-starting point for doing the translations yourself. Search for the required files for any of the language prefixes above (e.g. _en_US), copy the files, and rename your new files using the appropriate language code [prefix][2]. Please send a note to [the VIVO Tech group][3]
-to find out if someone else is already working on a translation.
+If a directory for your desired language does not exist, you may copy one of
+the existing directories in this repository to use as a starting point for
+doing the translations yourself. Rename your new directory using the appropriate
+language code [prefix][2]. Please send a note to [the VIVO Tech group][3] to
+find out if someone else is already working on a translation.  Additional
+information about developing a new translation is available on the wiki at
+[Developing a New Interface Language for VIVO][4]
 
-If you create a translation, please consider contributing your language files to the VIVO community.
+If you create a translation, please consider contributing your language files to
+the VIVO community.
 
-[1]: https://wiki.duraspace.org/display/VIVODOC110x/Internationalization#Internationalization-AddinganexistinglanguagetoyourVIVOsite
+[1]: https://wiki.duraspace.org/display/VIVODOC112x/Internationalization#Internationalization-AddinganexistinglanguagetoyourVIVOsite
 [2]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 [3]: mailto:vivo-tech@googlegroups.com
+[4]: https://wiki.lyrasis.org/display/VIVODOC112x/Developing+a+New+Interface+Language+for+VIVO

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ in the VIVO wiki for [Adding a language to VIVO][1].
 If a directory for your desired language does not exist, you may copy one of
 the existing directories in this repository to use as a starting point for
 doing the translations yourself. Rename your new directory using the appropriate
-language code [prefix][2]. Please send a note to [the VIVO Tech group][3] to
-find out if someone else is already working on a translation.  Additional
-information about developing a new translation is available on the wiki at
-[Developing a New Interface Language for VIVO][4].
+language code [prefix][2], and also rename the files within the various
+levels of subdirectories to end with the appropriate code. Please send a note
+to [the VIVO Tech group][3] to find out if someone else is already working on a
+translation.  Additional information about developing a new translation is
+available on the wiki at [Developing a New Interface Language for VIVO][4].
 
 If you create a translation, please consider contributing your language files to
 the VIVO community.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ doing the translations yourself. Rename your new directory using the appropriate
 language code [prefix][2]. Please send a note to [the VIVO Tech group][3] to
 find out if someone else is already working on a translation.  Additional
 information about developing a new translation is available on the wiki at
-[Developing a New Interface Language for VIVO][4]
+[Developing a New Interface Language for VIVO][4].
 
 If you create a translation, please consider contributing your language files to
 the VIVO community.


### PR DESCRIPTION
https://jira.lyrasis.org/browse/VIVO-1979

Updates text to reflect fact that American English is now part of this repository, include current list of available languages, and provide current instructions for adding a new language translation.

No functional changes.