### PR TITLE
Add tag <a> to reset passwords email link

### DIFF
--- a/de_DE/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_de_DE.ftl
+++ b/de_DE/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_de_DE.ftl
@@ -33,7 +33,7 @@
 			um Ihr Passwort über unseren Server zurückzusetzen. 
         </p>
         
-        <p>${passwordLink}</p>
+        <p><a href="${passwordLink}" title="password">${passwordLink}</a> </p>
         
         <p>Vielen Dank!</p>
     </body>

--- a/en_CA/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_en_CA.ftl
+++ b/en_CA/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_en_CA.ftl
@@ -32,7 +32,7 @@
             using our secure server.
         </p>
         
-        <p>${passwordLink}</p>
+        <p><a href="${passwordLink}" title="password">${passwordLink}</a> </p>
         
         <p>Thank you!</p>
     </body>

--- a/en_US/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_en_US.ftl
+++ b/en_US/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_en_US.ftl
@@ -32,7 +32,7 @@
             using our secure server.
         </p>
         
-        <p>${passwordLink}</p>
+        <p><a href="${passwordLink}" title="password">${passwordLink}</a> </p>
         
         <p>Thank you!</p>
     </body>

--- a/es/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_es.ftl
+++ b/es/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_es.ftl
@@ -33,7 +33,7 @@
             restablecer tu contraseña usando nuestro servidor seguro.
         </p>
         
-        <p>${passwordLink}</p>
+        <p><a href="${passwordLink}" title="password">${passwordLink}</a> </p>
         
         <p>¡Gracias!</p>
     </body>

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_fr_CA.ftl
@@ -32,7 +32,7 @@
             using our secure server.
         </p>
         
-        <p>${passwordLink}</p>
+        <p><a href="${passwordLink}" title="password">${passwordLink}</a> </p>
         
         <p>Thank you!</p>
     </body>

--- a/pt_BR/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_pt_BR.ftl
+++ b/pt_BR/webapp/src/main/webapp/templates/freemarker/userAccounts-passwordResetPendingEmail_pt_BR.ftl
@@ -33,7 +33,7 @@
             redefinir sua senha usando o nosso servidor seguro.
         </p>
         
-        <p>${passwordLink}</p>
+        <p><a href="${passwordLink}" title="password">${passwordLink}</a> </p>
         
         <p>Obrigado!</p>
     </body>


### PR DESCRIPTION
This PR adds <a> tag to password restore link to make it clickable.

*How should this be tested?*
Configure smtp server. Create a user and reset user's password. 
Recieved email should contain clickable link to password reset page.