### PR TITLE
Added translations for password_change_invalid_key message

### DIFF
--- a/de_DE/webapp/src/main/webapp/i18n/all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/all_de_DE.properties
@@ -168,6 +168,7 @@ account_already_activated = Das Konto für {0} wurde bereits aktiviert.
 
 cant_change_password_while_logged_in = Sie können das Passwort für {0} nicht zurücksetzen während Sie als {1} angemeldet sind. Bitte melden Sie ab und versuchen Sie es erneut.
 password_change_not_pending = Das Passwort für {0} wurde bereits zurückgesetzt.
+password_change_invalid_key = Der Link, den Sie für {0} verwendet haben, ist ungültig. Bitten Sie den Site-Administrator, den Link erneut zu senden. 
 password_changed_subject = Passwort geändert.
 account_no_longer_exists = Das Konto, für das Sie versuchen ein Passwort zu setzen, ist nicht mehr verfügbar. Bitte kontaktieren Sie Ihren Systemadministrator, wenn Sie denken, dass dies ein Fehler ist.
 password_saved = Ihr Passwort wurde gespeichert.

--- a/en_CA/webapp/src/main/webapp/i18n/all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/all_en_CA.properties
@@ -176,6 +176,7 @@ account_already_activated = The account for {0} has already been activated.
 cant_change_password_while_logged_in = You may not reset the password for {0} while you are logged in as {1}. \
 Please log out and try again.
 password_change_not_pending = The password for {0} has already been reset.
+password_change_invalid_key = The link you used for {0} is invalid. Please ask your system administrator to resend the link.
 password_changed_subject = Password changed.
 account_no_longer_exists = The account you are trying to set a password on is no longer available. \
 Please contact your system administrator if you think this is an error.

--- a/en_US/webapp/src/main/webapp/i18n/all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/all_en_US.properties
@@ -176,6 +176,7 @@ account_already_activated = The account for {0} has already been activated.
 cant_change_password_while_logged_in = You may not reset the password for {0} while you are logged in as {1}. \
 Please log out and try again.
 password_change_not_pending = The password for {0} has already been reset.
+password_change_invalid_key = The link you used for {0} is invalid. Please ask site administrator to resend the link.
 password_changed_subject = Password changed.
 account_no_longer_exists = The account you are trying to set a password on is no longer available. \
 Please contact your system administrator if you think this is an error.

--- a/es/webapp/src/main/webapp/i18n/all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/all_es.properties
@@ -200,6 +200,7 @@ account_already_activated = La cuenta para {0} ya se ha activado.
 
 cant_change_password_while_logged_in = El usuario no puede cambiar la contraseña de {0} mientras está conectado como {1}. Por favor, cierre la sesión y vuelva a intentarlo.
 password_change_not_pending = La contraseña para {0} ya se ha restablecido.
+password_change_invalid_key = El vínculo que usó para {0} no es válido. Solicite al administrador del sitio que vuelva a enviar el enlace. 
 password_changed_subject = Contraseña cambiada.
 account_no_longer_exists = La cuenta a la que está tratando de establecer una contraseña, ya no está disponible. Por favor, póngase en contacto con el administrador del sistema.
 password_saved = Su contraseña ha sido guardada.

--- a/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties
@@ -180,6 +180,7 @@ account_already_activated = Le compte de {0} a déjà été activé.
 cant_change_password_while_logged_in = Vous ne pouvez pas activer le compte {0} lorsque vous êtes connecté en tant que {1}. \
 Veuillez essayer de vous reconnecter.
 password_change_not_pending = Le mot de passe de {0} a déjà été réinitialisé.
+password_change_invalid_key = Le lien que vous avez utilisé pour {0} n'est pas valide. Veuillez demander à l'administrateur du site de renvoyer le lien. 
 password_changed_subject = Le mot de passe a été mis à jour.
 account_no_longer_exists = Le compte pour lequel vous tentez de modifier le mot de passe a été supprimé. \
 Veuillez contacter votre administrateur système s'il s'agit d'une erreur.

--- a/pt_BR/webapp/src/main/webapp/i18n/all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/all_pt_BR.properties
@@ -210,6 +210,7 @@ account_already_activated = A conta para {0} já foi ativado.
 cant_change_password_while_logged_in = Você não pode redefinir a senha para {0} enquanto você está logado como {1}. \
 Por favor, saia e tente novamente.
 password_change_not_pending = A senha para {0} já foi redefinida.
+password_change_invalid_key = O link que você usou para {0} é inválido. Peça ao administrador do site para reenviar o link. 
 password_changed_subject = Senha alterada.
 account_no_longer_exists = A conta que você está tentando definir uma senha no não está mais disponível. \
 Entre em contato com o administrador do sistema, se você acha que isso é um erro.


### PR DESCRIPTION
# What does this pull request do?
This PR adds translationd for "invalid key" message for cases when user used link to activate account or reset password with invalid key.
The message replaces used now for this matter password_change_not_pending, which doesn't describe real error to the user ( Example in English "The password for {0} has already been reset." )
# Additional Notes:
Use in combination with PR https://github.com/vivo-project/Vitro/pull/234

# Interested parties
@VIVO-project/vivo-committers
